### PR TITLE
SRE-6578 fix exception in schema refresh caused by missing import

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -21,6 +21,7 @@ from redash.query_runner import (
     register,
 )
 from redash.settings import QUERY_RESULTS_MAX_ROWS, QUERY_RESULTS_MAX_ROWS_CONFLUENCE
+from redash.utils import json_loads
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Caused by rebase with custom change which includes the call to `json_loads`